### PR TITLE
V27.1 Homebrew

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,6 @@ jobs:
       - run: brew test-bot --only-setup
 
       - run: brew test-bot --only-formulae
-        if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/Aliases/typesense-server
+++ b/Aliases/typesense-server
@@ -1,1 +1,1 @@
-../Formula/typesense-server@27.0.rb
+../Formula/typesense-server@27.1.rb

--- a/Formula/typesense-server@27.1.rb
+++ b/Formula/typesense-server@27.1.rb
@@ -1,15 +1,15 @@
 class TypesenseServerAT270 < Formula
   desc "Search Engine; Open Source, Lightning fast, In-Memory, Typo Tolerant"
   homepage "https://typesense.org"
-  version "27.0"
+  version "27.1"
   license "GPL-3.0"
 
   if Hardware::CPU.arm?
-    url "https://dl.typesense.org/releases/27.1/typesense-server-27.0-darwin-arm64.tar.gz"
+    url "https://dl.typesense.org/releases/27.1/typesense-server-27.1-darwin-arm64.tar.gz"
     sha256 "ef478f0a932f38ded3de46de7919a4a90809cc480d344d16ed5a5c6a9ccb177e"
   else
-    url "https://dl.typesense.org/releases/27.1/typesense-server-27.0-darwin-amd64.tar.gz"
-    sha256 "ede783ef04526627ee8de3f2003e03dfcac632437c1f1ed3bc15652ce5a13d24"
+    url "https://dl.typesense.org/releases/27.1/typesense-server-27.1-darwin-amd64.tar.gz"
+    sha256 "6bca78ffe7423b2c76fec961ca758983a32cc0c891f583f4d59aeb8e47c085e1"
   end
 
   def install

--- a/Formula/typesense-server@27.1.rb
+++ b/Formula/typesense-server@27.1.rb
@@ -1,4 +1,4 @@
-class TypesenseServerAT270 < Formula
+class TypesenseServerAT271 < Formula
   desc "Search Engine; Open Source, Lightning fast, In-Memory, Typo Tolerant"
   homepage "https://typesense.org"
   version "27.1"


### PR DESCRIPTION
When I tried to [install 27.1 from Homebrew](https://typesense.org/docs/guide/install-typesense.html#mac-via-homebrew), I hit an error. I noticed the file links to 27.0, so I updated the download URLs to point to 27.1 and changed the class name.

`Error: No available formula with the name "typesense/tap/typesense-server@27.1". Did you mean typesense/tap/typesense-server@27.0, typesense/tap/typesense-server@26.0, typesense/tap/typesense-server@0.12.0, typesense/tap/typesense-server@0.25.1, typesense/tap/typesense-server@0.24.1, typesense/tap/typesense-server@0.23.1, typesense/tap/typesense-server@0.22.1, typesense/tap/typesense-server@0.21.0, typesense/tap/typesense-server@0.17.0, typesense/tap/typesense-server@0.13.0, typesense/tap/typesense-server@0.14.0, typesense/tap/typesense-server@0.15.0, typesense/tap/typesense-server@0.16.0, typesense/tap/typesense-server@0.16.1, typesense/tap/typesense-server@0.19.0, typesense/tap/typesense-server@0.18.0, typesense/tap/typesense-server@0.20.0, typesense/tap/typesense-server@0.22.0, typesense/tap/typesense-server@0.22.2, typesense/tap/typesense-server@0.23.0, typesense/tap/typesense-server@0.24.0, typesense/tap/typesense-server@0.25.0 or typesense/tap/typesense-server@0.25.2?
In formula file: /opt/homebrew/Library/Taps/typesense/homebrew-tap/Formula/typesense-server@27.1.rb
Expected to find class TypesenseServerAT271, but only found: TypesenseServerAT270.`